### PR TITLE
Patch vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,24 +2,11 @@
   "editor.fontSize": 18,
   "editor.fontFamily": "'Cascadia Code', Verdana, Arial, Consolas, 'sans-serif', Monospace",
   "editor.formatOnSave": true,
-  "[javascript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
   },
-  "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "[javascriptreact]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "[typescriptreact]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "[css]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.formatOnSave": true
-  },
-  "[scss]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.formatOnSave": true
-  }
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.fontSize": 18,
-  "editor.fontFamily": "'Verdana', Monaspace, 'Arial', Consolas, 'sans-serif', monospace",
+  "editor.fontFamily": "'Cascadia Code', Verdana, Arial, Consolas, 'sans-serif', Monospace",
   "editor.formatOnSave": true,
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.fontSize": 18,
-  "editor.fontFamily": "'Verdana', 'Arial', 'Helvetica', 'Tahoma', 'sans-serif'",
+  "editor.fontFamily": "'Verdana', Monaspace, 'Arial', Consolas, 'sans-serif', monospace",
   "editor.formatOnSave": true,
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"


### PR DESCRIPTION
This pull request updates the VS Code workspace settings to standardize code formatting and linting behavior. The changes focus on using ESLint for code actions on save, updating the font families to better support Terminals, and removing language-specific formatter settings in favor of a more unified configuration.

Editor configuration improvements:

- [x] Change `editor.fontFamily` to use `'Cascadia Code'` and other monospaced fonts for improved code readability.
- [x] Add `editor.codeActionsOnSave` with ESLint's `fixAll` action to automatically fix linting issues on save.
- [x] Remove language-specific `editor.defaultFormatter` settings for JavaScript, TypeScript, React, CSS, and SCSS, consolidating formatting behavior.
- [x] Add `eslint.validate` to ensure ESLint runs on JavaScript and JavaScript React files.